### PR TITLE
Now passing TokenStorage class to XeroClient

### DIFF
--- a/src/main/java/com/xero/api/XeroClient.java
+++ b/src/main/java/com/xero/api/XeroClient.java
@@ -25,6 +25,7 @@ import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 
 import com.google.api.client.http.HttpResponse;
+import com.xero.api.TokenStorage;
 import com.xero.model.*;
 
 public class XeroClient {
@@ -46,20 +47,18 @@ public class XeroClient {
 	
 	protected HttpServletRequest request;
 	protected HttpServletResponse response;
+	protected TokenStorage storage;
 	
-	public XeroClient(HttpServletRequest request, HttpServletResponse response) {
+	public XeroClient(HttpServletRequest request, HttpServletResponse response, TokenStorage storage) {
 		this.request = request;
 		this.response = response;
-		
-		// Get Xero API Resource - DEMONSTRATION ONLY get token from Cookie
-		TokenStorage storage = new TokenStorage();
+		this.storage = storage;
 		
 		OAuthAccessToken refreshToken = new OAuthAccessToken();
 		tokenTimestamp = storage.get(request, "tokenTimestamp");
 		
 		if(c.getAppType().equals("PARTNER") && refreshToken.isStale(tokenTimestamp))
 		{
-			
 			System.out.println("Time for a refresh");
 
 			refreshToken.setToken(storage.get(request, "token"));

--- a/src/main/java/com/xero/example/RequestResource.java
+++ b/src/main/java/com/xero/example/RequestResource.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.xero.api.TokenStorage;
 import com.xero.api.XeroClient;
 import com.xero.model.*;
 
@@ -88,7 +89,9 @@ public class RequestResource extends HttpServlet
 		String object = request.getParameter("object");
 		ArrayList<String> messages = new ArrayList<String>();
 		
-		XeroClient client = new XeroClient(request, response);
+		// Get Xero API Resource - DEMONSTRATION ONLY get token from Cookie
+		TokenStorage storage = new TokenStorage();
+		XeroClient client = new XeroClient(request, response, storage);
 		
 		SampleData data = new SampleData(client);
 		


### PR DESCRIPTION
This will allow dev to extend the TokenStorage class and pass it to
XeroClient for retrieval and storage of access tokens.