### PR TITLE
Remove extra load() call in Config

### DIFF
--- a/src/main/java/com/xero/api/Config.java
+++ b/src/main/java/com/xero/api/Config.java
@@ -42,7 +42,6 @@ public class Config {
 		if(instance == null) 
 		{
 			instance = new Config("config.json");
-			instance.load();
 		}
 	    return instance;
 	}


### PR DESCRIPTION
I was single stepping the config load just now and I noticeed that it called the Config load method got called twice.

I think this is the right one to delete but it is untested and I don't know Java, just some Kotlin...