### PR TITLE
Allow config.json and private key to work within a jar and minor documentation tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add this dependency and repository to your POM.xml
       </repository>
     </repositories>
 
-####Working with sbt?
+#### Working with sbt?
 We have a build.sbt file defined in the root.
 
 
@@ -219,12 +219,12 @@ List<Invoice> InvoiceList24hour = client.getInvoices(cal.getTime(),null,null);
 System.out.println("How many invoices modified in last 24 hours?: " + InvoiceList24hour.size());
 ```
 
-##Acknowledgement
+## Acknowledgement
 
 Special thanks to [Connectifier](https://github.com/connectifier) and [Ben Mccann](https://github.com/benmccann).  Marshalling and Unmarshalling in XeroClient was derived and extended from [Xero-Java-Client](https://github.com/connectifier/xero-java-client)
   
 
-##License
+## License
 
 This software is published under the [MIT License](http://en.wikipedia.org/wiki/MIT_License).
 

--- a/src/main/java/com/xero/api/Config.java
+++ b/src/main/java/com/xero/api/Config.java
@@ -109,7 +109,7 @@ public class Config {
 	public void load() 
 	{
 		
-		InputStream inputStream = Config.class.getResourceAsStream(configFile);
+		InputStream inputStream = Config.class.getResourceAsStream("/" + configFile);
 		InputStreamReader reader = new InputStreamReader(inputStream);
 
 		JSONParser parser = new JSONParser();

--- a/src/main/java/com/xero/api/Config.java
+++ b/src/main/java/com/xero/api/Config.java
@@ -1,14 +1,13 @@
 package com.xero.api;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.net.URL;
-
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 
 public class Config {
 
@@ -110,15 +109,14 @@ public class Config {
 	public void load() 
 	{
 		
-		final ClassLoader loader = Config.class.getClassLoader();
-		URL path = loader.getResource(configFile);
-		File f = new File(path.getFile());
-		
+		InputStream inputStream = Config.class.getResourceAsStream(configFile);
+		InputStreamReader reader = new InputStreamReader(inputStream);
+
 		JSONParser parser = new JSONParser();
 		  
 		Object obj = null;
 		try {
-			obj = parser.parse(new FileReader(f));
+			obj = parser.parse(reader);
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
 		} catch (IOException e) {
@@ -195,8 +193,7 @@ public class Config {
 		if (jsonObject.containsKey("PrivateKeyCert")) 
 		{
 			String privateKeyCert = (String) jsonObject.get("PrivateKeyCert");
-			URL privateKeyPath = loader.getResource(privateKeyCert);
-			PATH_TO_PRIVATE_KEY_CERT = privateKeyPath.getPath();
+			PATH_TO_PRIVATE_KEY_CERT = privateKeyCert;
 			PRIVATE_KEY_PASSWORD = (String) jsonObject.get("PrivateKeyPassword");
 		}
 	}

--- a/src/main/java/com/xero/api/RsaSigner.java
+++ b/src/main/java/com/xero/api/RsaSigner.java
@@ -16,7 +16,7 @@ public class RsaSigner implements Signer {
 	public RsaSigner(Config config) {
 
 		InputStream oauthPKCS12Stream = null;
-		oauthPKCS12Stream = getClass().getResourceAsStream(config.getPathToPrivateKey());
+		oauthPKCS12Stream = getClass().getResourceAsStream("/" + config.getPathToPrivateKey());
 		String oauthPKCS12Password = config.getPrivateKeyPassword();
 
 		KeyStore oauthKeyStore = null;

--- a/src/main/java/com/xero/api/RsaSigner.java
+++ b/src/main/java/com/xero/api/RsaSigner.java
@@ -1,20 +1,13 @@
 package com.xero.api;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException; 
-import java.io.InputStream;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
-import java.security.PrivateKey;
-
-import java.util.Enumeration;
-
 import com.google.api.client.auth.oauth.OAuthHmacSigner;
 import com.google.api.client.auth.oauth.OAuthRsaSigner;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.*;
+import java.security.cert.CertificateException;
+import java.util.Enumeration;
 
 public class RsaSigner implements Signer {
 
@@ -23,12 +16,7 @@ public class RsaSigner implements Signer {
 	public RsaSigner(Config config) {
 
 		InputStream oauthPKCS12Stream = null;
-		try {
-			oauthPKCS12Stream = new FileInputStream(config.getPathToPrivateKey());
-		} catch (FileNotFoundException e4) {
-			// TODO Auto-generated catch block
-			e4.printStackTrace();
-		}
+		oauthPKCS12Stream = getClass().getResourceAsStream(config.getPathToPrivateKey());
 		String oauthPKCS12Password = config.getPrivateKeyPassword();
 
 		KeyStore oauthKeyStore = null;


### PR DESCRIPTION
Config.json and private key file loading needs to be performed as a stream as when the files are inside a jar file, the FileReaders do not work as intended. 

Spring boot built one-jars use the single jar method and the xero java client does not work inside there without stream reading.

Also minor markdown tweaks for the layout to work with github.