### PR TITLE
sbt build file is redundant and duplicates pom.xml. Using a sbt resol…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ Add this dependency and repository to your POM.xml
       </repository>
     </repositories>
 
-#### Working with sbt?
-We have a build.sbt file defined in the root.
-
 
 ### Configure
 The Xero Java SDK is easily configured using an external JSON file to configure values unique to your Application. This is the default configuration method, however you can implement the `Config` interface and pass it to the `XeroClient`.

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,0 @@
-name := "xero-java-sdk"
-
-organization := "com.xero"
-
-libraryDependencies += "com.google.oauth-client" % "google-oauth-client" % "1.20.0"
-libraryDependencies += "com.googlecode.json-simple" % "json-simple" % "1.1.1"
-libraryDependencies += "com.xero" % "xero-accounting-api-schema" % "0.0.3"
-
-licenses += ("MIT", url("http://opensource.org/licenses/MIT"))


### PR DESCRIPTION
…ver to this project's maven repo is the recommended way to obtain releases.

The original committer used a build.sbt most likely before the maven repo branch was available, however, using a sbt resolver with the maven repo is a lot easier to obtain the library.