### PR TITLE
Updated to Xero schema 0.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>com.xero</groupId>
 			<artifactId>xero-accounting-api-schema</artifactId>
-			<version>0.0.3</version>
+			<version>0.0.4</version>
 		</dependency>
 	</dependencies>
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.xero</groupId>
 	<artifactId>xero-java-sdk</artifactId>
 	<packaging>jar</packaging>
-	<version>0.3.3</version>
+	<version>0.3.4</version>
 	<name>Xero-Java SDK</name>
 	<url>http://maven.apache.org</url>
 	<dependencies>


### PR DESCRIPTION
If https://github.com/XeroAPI/XeroAPI-Schemas/pull/53 gets merged, this will ensure that the Xero Java Client can retrieve the OrganisationID from the Organisation API.

Ref: https://github.com/XeroAPI/XeroAPI-Schemas/issues/52