### PR TITLE
Fixed null pointer exceptions caused by missing or broken configuration file

### DIFF
--- a/src/main/java/com/xero/api/JsonConfig.java
+++ b/src/main/java/com/xero/api/JsonConfig.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import static java.lang.String.format;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -167,8 +168,11 @@ public class JsonConfig implements Config {
     AUTH_CALLBACK_URL = authCallbackUrl;
   }
 
-  public void load() {
+  private void load() {
     InputStream inputStream = JsonConfig.class.getResourceAsStream("/" + configFile);
+    if (inputStream == null) {
+        throw new XeroClientException(format("Config file '%s' could not be opened. Missing file?", configFile));
+    }
     InputStreamReader reader = new InputStreamReader(inputStream);
 
     JSONParser parser = new JSONParser();
@@ -177,11 +181,11 @@ public class JsonConfig implements Config {
     try {
       obj = parser.parse(reader);
     } catch (FileNotFoundException e) {
-      e.printStackTrace();
+        throw new XeroClientException(format("Config file '%s' not found", configFile), e);
     } catch (IOException e) {
-      e.printStackTrace();
+        throw new XeroClientException(format("IO error reading config file '%s' not found", configFile), e);
     } catch (ParseException e) {
-      e.printStackTrace();
+        throw new XeroClientException(format("Parse error reading config file '%s' not found", configFile), e);
     }
     JSONObject jsonObject = (JSONObject) obj;
 

--- a/src/main/java/com/xero/api/XeroClientException.java
+++ b/src/main/java/com/xero/api/XeroClientException.java
@@ -1,0 +1,30 @@
+package com.xero.api;
+
+/**
+ * Exception thrown by Xero Java API if there is an error which is not related
+ * to remote API calls (like for example no config).
+ *
+ * @author GideonLeGrange <gideon@legrange.me>
+ */
+public class XeroClientException extends RuntimeException {
+
+    /**
+     * Create new exception.
+     *
+     * @param message Error message
+     */
+    public XeroClientException(String message) {
+        super(message);
+    }
+
+    /**
+     * Create new exception.
+     *
+     * @param message Error message
+     * @param cause Original exception causing this error.
+     */
+    public XeroClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}


### PR DESCRIPTION
This PR fixes two related problems:
* The user instantiates the API with a missing JSON config file. This causes a null pointer error
* There is a problem reading the JSON config which causes a further null pointer (after printing stack traces)

To fix this, I introduce a new exception `XeroClientException`. I did not want to re-use `XeroApiException` since this is thrown on failures which happen before the remote API is called. `XeroClientException` extends `RuntimeException` so there should be no impact on backwards compatibility. 