### PR TITLE
add period and timeframe parameters to getReportProfitAndLoss, getRep…

### DIFF
--- a/src/main/java/com/xero/api/XeroClient.java
+++ b/src/main/java/com/xero/api/XeroClient.java
@@ -1577,7 +1577,9 @@ public class XeroClient {
                                         String trackingOptionId1,
                                         String trackingOptionId2,
                                         boolean standardLayout,
-                                        boolean paymentsOnly) throws IOException {
+                                        boolean paymentsOnly,
+                                        Integer periods,
+                                        String timeframe) throws IOException {
         Map<String, String> params = new HashMap<>();
         addToMapIfNotNull(params, "where", where);
         addToMapIfNotNull(params, "order", order);
@@ -1586,6 +1588,8 @@ public class XeroClient {
         addToMapIfNotNull(params, "trackingOptionID2", trackingOptionId2);
         addToMapIfNotNull(params, "standardLayout", standardLayout);
         addToMapIfNotNull(params, "paymentsOnly", paymentsOnly);
+        addToMapIfNotNull(params, "periods", periods);
+        addToMapIfNotNull(params, "timeframe", timeframe);
         return singleResult(get("reports/BalanceSheet", null, params).getReports().getReport());
     }
 
@@ -1600,7 +1604,7 @@ public class XeroClient {
         return singleResult(get("reports/BankStatement", null, params).getReports().getReport());
     }
 
-    public Report getReportBudgetSummary(String where, String order, String date, int periods, int timeframe)
+    public Report getReportBudgetSummary(String where, String order, String date, Integer periods, Integer timeframe)
         throws IOException {
         Map<String, String> params = new HashMap<>();
         addToMapIfNotNull(params, "where", where);
@@ -1628,7 +1632,9 @@ public class XeroClient {
                                       String trackingCategoryId2,
                                       String trackingOptionId2,
                                       boolean standardLayout,
-                                      boolean paymentsOnly) throws IOException {
+                                      boolean paymentsOnly,
+                                      Integer periods,
+                                      String timeframe) throws IOException {
         Map<String, String> params = new HashMap<>();
         addToMapIfNotNull(params, "where", where);
         addToMapIfNotNull(params, "order", order);
@@ -1640,6 +1646,8 @@ public class XeroClient {
         addToMapIfNotNull(params, "trackingOptionID2", trackingOptionId2);
         addToMapIfNotNull(params, "standardLayout", standardLayout);
         addToMapIfNotNull(params, "paymentsOnly", paymentsOnly);
+        addToMapIfNotNull(params, "periods", periods);
+        addToMapIfNotNull(params, "timeframe", timeframe);
         return singleResult(get("reports/ProfitAndLoss", null, params).getReports().getReport());
     }
 

--- a/src/main/java/com/xero/example/RequestResourceServlet.java
+++ b/src/main/java/com/xero/example/RequestResourceServlet.java
@@ -851,7 +851,7 @@ public class RequestResourceServlet extends HttpServlet
 				Report newReportAgedReceivablesByContact = client.getReportAgedReceivablesByContact(AgedPayablesByContactList.get(num20).getContactID(), null, null, null, "1/1/2016", "1/1/2017");
 				messages.add("Get Aged Receivables By Contact Reports for " +  AgedPayablesByContactList.get(num20).getName() + " - Report ID " + newReportAgedReceivablesByContact.getReportID() );
 				
-				Report newReportBalanceSheet = client.getReportBalanceSheet(null, null, "3/3/2017", null, null, true, false);
+				Report newReportBalanceSheet = client.getReportBalanceSheet(null, null, "3/3/2017", null, null, true, false, null, null);
 				messages.add("Get Balance Sheet Report on " +  newReportBalanceSheet.getReportDate() + " - Name: " + newReportBalanceSheet.getReportTitles().getReportTitle().get(1).toString() );
 							
 				List<Account> accountForBankStatement = client.getAccounts(null,"Type==\"BANK\"",null);
@@ -868,7 +868,7 @@ public class RequestResourceServlet extends HttpServlet
 				Report newExecutiveSummary = client.getExecutiveSummary(null, null,"1/1/2017");			
 				messages.add("Get Executive Summary Report on " +  newExecutiveSummary.getReportDate() + " - Name: " + newExecutiveSummary.getReportName() );
 	
-				Report newReportProfitLoss = client.getReportProfitLoss(null,null, "9/1/2016", "1/1/2017", null, null, null, null, true, false);		
+				Report newReportProfitLoss = client.getReportProfitLoss(null,null, "9/1/2016", "1/1/2017", null, null, null, null, true, false, null, null);
 				messages.add("Get Profit Loss Report on " +  newReportProfitLoss.getReportDate() + " - Name: " + newReportProfitLoss.getReportName() );
 			
 				Report newTrialBalance = client.getReportTrialBalance("9/1/2016", true);		


### PR DESCRIPTION
Hi, I added the parameter **periods** and **timeframe** to the **getReportBalanceSheet** and **getReportProfitAndLoss** and changed their type in **getReportBudgetSummary** to Integer, that is is nullable. according to the [documentation](https://developer.xero.com/documentation/api/reports#BudgetSummary) it is optional.

I also noticed that a parameter is called trackingOptionID1 in the java code, but trackingOptionID in the [documentation](https://developer.xero.com/documentation/api/reports#ProfitAndLoss).

regards,
Peter 