### PR TITLE
Application Firewall Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.xero</groupId>
-	<artifactId>xero-java-sdk</artifactId>
+	<artifactId>xero-java-sdk-appfw-mods</artifactId>
 	<packaging>jar</packaging>
 	<version>0.6.2</version>
 	<name>Xero-Java SDK</name>

--- a/src/main/java/com/xero/api/Config.java
+++ b/src/main/java/com/xero/api/Config.java
@@ -40,6 +40,12 @@ public interface Config {
 
     String getDecimalPlaces();
 
+    String getAppFirewallHostname();
+
+    String getAppFirewallUrlPrefix();
+
+    boolean isUsingAppFirewall();
+
     // SETTERS
 
     void setConsumerKey(String consumerKey);
@@ -55,5 +61,10 @@ public interface Config {
     void setReadTimeout(int readTimeout);
 
     void setDecimalPlaces(String decimalPlaces);
-    
+
+    void setUsingAppFirewall(boolean usingAppFirewall);
+
+    void setAppFirewallHostname(String appFirewallHostname);
+
+    void setAppFirewallUrlPrefix(String appFirewallUrlPrefix);
 }

--- a/src/main/java/com/xero/api/JsonConfig.java
+++ b/src/main/java/com/xero/api/JsonConfig.java
@@ -33,6 +33,9 @@ public class JsonConfig implements Config {
   private int CONNECT_TIMEOUT = 60;
   private int READ_TIMEOUT = 60;
   private String DECIMAL_PLACES = null;
+  private boolean USING_APP_FIREWALL = false;
+  private String APP_FIREWALL_HOSTNAME;
+  private String APP_FIREWALL_URL_PREFIX;
 
   private String configFile;
 
@@ -149,7 +152,22 @@ public class JsonConfig implements Config {
     return DECIMAL_PLACES;
   }
 
-  // SETTERS
+  @Override
+  public boolean isUsingAppFirewall() {
+    return USING_APP_FIREWALL;
+  }
+
+  @Override
+  public String getAppFirewallHostname() {
+    return APP_FIREWALL_HOSTNAME;
+  }
+
+  @Override
+  public String getAppFirewallUrlPrefix() {
+    return APP_FIREWALL_URL_PREFIX;
+  }
+
+// SETTERS
 
   @Override
   public void setConsumerKey(String consumerKey) {
@@ -187,6 +205,21 @@ public class JsonConfig implements Config {
   public void setDecimalPlaces(String decimalPlaces) {
     // 2 or 4
     DECIMAL_PLACES = decimalPlaces;
+  }
+
+  @Override
+    public void setUsingAppFirewall(boolean usingAppFirewall) {
+      this.USING_APP_FIREWALL = usingAppFirewall;
+  }
+
+  @Override
+  public void setAppFirewallHostname(String appFirewallHostname) {
+      this.APP_FIREWALL_HOSTNAME = appFirewallHostname;
+  }
+
+  @Override
+  public void setAppFirewallUrlPrefix(String appFirewallUrlPrefix) {
+      this.APP_FIREWALL_URL_PREFIX = appFirewallUrlPrefix;
   }
 
   private void load() {
@@ -284,6 +317,18 @@ public class JsonConfig implements Config {
 
     if (jsonObject.containsKey("DecimalPlaces")) {
     	DECIMAL_PLACES = (String) jsonObject.get("DecimalPlaces");
+    }
+
+    if (jsonObject.containsKey("usingAppFirewall")) {
+        USING_APP_FIREWALL = (boolean) jsonObject.get("usingAppFirewall");
+
+        if (jsonObject.containsKey("appFirewallHostname")) {
+            APP_FIREWALL_HOSTNAME = (String) jsonObject.get("appFirewallHostname");
+        }
+
+        if (jsonObject.containsKey("appFirewallUrlPrefix")) {
+            APP_FIREWALL_URL_PREFIX = (String) jsonObject.get("appFirewallUrlPrefix");
+        }
     }
   }
 }

--- a/src/main/java/com/xero/api/OAuthAccessToken.java
+++ b/src/main/java/com/xero/api/OAuthAccessToken.java
@@ -198,6 +198,9 @@ public class OAuthAccessToken {
 
     OAuthParameters result = new OAuthParameters();
     result.consumerKey = config.getConsumerKey();
+    result.usingAppFirewall = config.isUsingAppFirewall();
+    result.appFirewallHostname = config.getAppFirewallHostname();
+    result.appFirewallUrlPrefix = config.getAppFirewallUrlPrefix();
     result.token = tempToken;
     result.verifier = verifier;
     result.signer = signer;

--- a/src/main/java/com/xero/api/OAuthGetTemporaryToken.java
+++ b/src/main/java/com/xero/api/OAuthGetTemporaryToken.java
@@ -1,0 +1,63 @@
+package com.xero.api;
+
+/**
+ * Replace the google OAuth API Client Class of the same name so that we can use
+ * our own modified version of OAuthParameters and be able to create a customized
+ * signature to deal with the L7 Application Firewall
+ *
+ * @author <a href="jvogtle@paychex.com">John Vogtle</a>
+ */
+
+import com.google.api.client.auth.oauth.OAuthCredentialsResponse;
+import com.google.api.client.auth.oauth.OAuthSigner;
+import com.google.api.client.http.*;
+
+import java.io.IOException;
+
+public class OAuthGetTemporaryToken extends GenericUrl {
+
+    public String callback;
+    public HttpTransport transport;
+    public String consumerKey;
+    public OAuthSigner signer;
+    protected boolean usePost;
+
+    private boolean usingAppFirewall;
+    private String appFirewallHostname = "";
+    private String appFirewallUrlPrefix = "";
+
+    public OAuthGetTemporaryToken(String authorizationServerUrl) {
+        super(authorizationServerUrl);
+    }
+
+    public OAuthGetTemporaryToken(String authorizationServerUrl,
+                                  boolean usingAppFirewall, String appFirewallHostname, String appFirewallUrlPrefix) {
+        super(authorizationServerUrl);
+        this.usingAppFirewall = usingAppFirewall;
+        this.appFirewallHostname = appFirewallHostname;
+        this.appFirewallUrlPrefix = appFirewallUrlPrefix;
+    }
+
+
+    public final OAuthCredentialsResponse execute() throws IOException {
+       HttpRequestFactory requestFactory = this.transport.createRequestFactory();
+       HttpRequest request = requestFactory.buildRequest(this.usePost ? "POST" : "GET", this, (HttpContent)null);
+       this.createParameters().intercept(request);
+       HttpResponse response = request.execute();
+       response.setContentLoggingLimit(0);
+       OAuthCredentialsResponse oauthResponse = new OAuthCredentialsResponse();
+       UrlEncodedParser.parse(response.parseAsString(), oauthResponse);
+       return oauthResponse;
+    }
+
+    public OAuthParameters createParameters() {
+        OAuthParameters result = new OAuthParameters();
+        result.usingAppFirewall = this.usingAppFirewall;
+        result.appFirewallHostname = this. appFirewallHostname;
+        result.appFirewallUrlPrefix = this.appFirewallUrlPrefix;
+        result.consumerKey = this.consumerKey;
+        result.signer = this.signer;
+        result.callback = this.callback;
+        return result;
+    }
+}

--- a/src/main/java/com/xero/api/OAuthParameters.java
+++ b/src/main/java/com/xero/api/OAuthParameters.java
@@ -78,7 +78,28 @@ public class OAuthParameters implements HttpExecuteInterceptor, HttpRequestIniti
 	 */
 	public String version;
 
-	private static final PercentEscaper ESCAPER = new PercentEscaper("-_.~", false);
+    /**
+     * A value of true indicates that server is sitting behind and application firewall (e.g. L7)
+     * Values for hostname and URL's will be adjusted when calculating oauth signatures as the
+     * application firewall will be changing the request
+     */
+    public boolean usingAppFirewall = false;
+
+    /**
+     * The hostname used for communicating through the application firewall.  If the url hostname
+     * matches this, the value of "api.xero.com" will be used instead when calculating the oauth
+     * signature.
+     */
+    public String appFirewallHostname = "";
+    private static final String XERO_API_HOST = "api.xero.com";
+
+    /**
+     * The prefix the application firewall uses to identify mappings for it's own URL rewriting.
+     * The value of the prefix will be stripped from the URL when calculating the oauth signature.
+     */
+    public String appFirewallUrlPrefix = "";
+
+    private static final PercentEscaper ESCAPER = new PercentEscaper("-_.~", false);
 
 	/**
 	 * Computes a nonce based on the hex string of a random non-negative long, setting the value of
@@ -153,8 +174,17 @@ public class OAuthParameters implements HttpExecuteInterceptor, HttpRequestIniti
 		GenericUrl normalized = new GenericUrl();
 		String scheme = requestUrl.getScheme();
 		normalized.setScheme(scheme);
-		normalized.setHost(requestUrl.getHost());
-		normalized.setPathParts(requestUrl.getPathParts());
+		if (usingAppFirewall && (requestUrl.getHost().equals(appFirewallHostname))) {
+			normalized.setHost(XERO_API_HOST);
+		} else {
+		    normalized.setHost(requestUrl.getHost());
+		}
+		if (usingAppFirewall &&(requestUrl.getRawPath().startsWith(appFirewallUrlPrefix))) {
+		    String modifiedPath = requestUrl.getRawPath().replace(appFirewallUrlPrefix, "");
+            normalized.setPathParts(requestUrl.toPathParts(modifiedPath));
+        } else {
+            normalized.setPathParts(requestUrl.getPathParts());
+        }
 		int port = requestUrl.getPort();
 		if ("http".equals(scheme) && port == 80 || "https".equals(scheme) && port == 443) {
 			port = -1;

--- a/src/main/java/com/xero/api/OAuthRequestResource.java
+++ b/src/main/java/com/xero/api/OAuthRequestResource.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.apache.http.HttpHost;
 
-import com.google.api.client.auth.oauth.OAuthParameters;
 import com.google.api.client.auth.oauth.OAuthSigner;
 import com.google.api.client.http.ByteArrayContent;
 import com.google.api.client.http.FileContent;
@@ -214,7 +213,10 @@ public class OAuthRequestResource extends GenericUrl {
 		OAuthSigner signer = signerFactory.createSigner(tokenSecret);
 
 		OAuthParameters result = new OAuthParameters();
-		result.consumerKey = config.getConsumerKey();;
+		result.consumerKey = config.getConsumerKey();
+		result.usingAppFirewall = config.isUsingAppFirewall();
+		result.appFirewallHostname = config.getAppFirewallHostname();
+		result.appFirewallUrlPrefix = config.getAppFirewallUrlPrefix();
 		result.token = token;
 		result.signer = signer;
 		return result;

--- a/src/main/java/com/xero/api/OAuthRequestToken.java
+++ b/src/main/java/com/xero/api/OAuthRequestToken.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import org.apache.http.HttpHost;
 
 import com.google.api.client.auth.oauth.OAuthCredentialsResponse;
-import com.google.api.client.auth.oauth.OAuthGetTemporaryToken;
 import com.google.api.client.auth.oauth.OAuthSigner;
 import com.google.api.client.http.apache.ApacheHttpTransport;
 
@@ -30,11 +29,17 @@ public class OAuthRequestToken {
   public void execute() {
     OAuthSigner signer = signerFactory.createSigner(null);
 
-    tokenRequest = new OAuthGetTemporaryToken(config.getRequestTokenUrl());
+    if (config.isUsingAppFirewall()) {
+        tokenRequest = new OAuthGetTemporaryToken(config.getRequestTokenUrl(), config.isUsingAppFirewall(),
+                                                    config.getAppFirewallHostname(), config.getAppFirewallUrlPrefix());
+    } else {
+        tokenRequest = new OAuthGetTemporaryToken(config.getRequestTokenUrl());
+
+    }
     tokenRequest.consumerKey = config.getConsumerKey();
     tokenRequest.callback = config.getRedirectUri();
 
-    ApacheHttpTransport.Builder transBuilder = new ApacheHttpTransport.Builder();
+      ApacheHttpTransport.Builder transBuilder = new ApacheHttpTransport.Builder();
     if (config.getProxyHost() != null && "" != config.getProxyHost()) {
       String proxy_host = config.getProxyHost();
       long proxy_port = config.getProxyPort();


### PR DESCRIPTION
Add capability to calculate OAuth Signatures when making calls through an application firewall such as a Computer Associates L7.  Changes the oauth_signature to be created based on the xero destination endpoints rather than those required by the application firewall.