### PR TITLE
fixed nullpointer exception in OAuthAccessToken.

### DIFF
--- a/src/main/java/com/xero/api/OAuthAccessToken.java
+++ b/src/main/java/com/xero/api/OAuthAccessToken.java
@@ -58,7 +58,7 @@ public class OAuthAccessToken {
   }
 
   public OAuthAccessToken build() throws IOException {
-    
+    httpclient = new XeroHttpContext(config).getHttpClient();
     return this;
   }
 


### PR DESCRIPTION
We noticed today that there is a NPE if you where using 

> public OAuthAccessToken build()

The problem was that the httpClient was not set. So we updated this. We tried to use the other builder, but where getting an oauth error (token has not been provided). With this fix it works again for us.