### PR TITLE
in OauthAccessToken.build() the connectTimeout and readTimeout is fet…

### DIFF
--- a/src/main/java/com/xero/api/OAuthAccessToken.java
+++ b/src/main/java/com/xero/api/OAuthAccessToken.java
@@ -51,13 +51,15 @@ public class OAuthAccessToken {
     this.tempTokenSecret = tempTokenSecret;
     this.connectTimeout = config.getConnectTimeout() * 1000;
 	this.readTimeout = config.getReadTimeout() * 1000;
-   
+
     	httpclient = new XeroHttpContext(config).getHttpClient();
-	
+
     return this;
   }
 
   public OAuthAccessToken build() throws IOException {
+    this.connectTimeout = config.getConnectTimeout() * 1000;
+    this.readTimeout = config.getReadTimeout() * 1000;
     httpclient = new XeroHttpContext(config).getHttpClient();
     return this;
   }


### PR DESCRIPTION
Hi,
in the OauthAccessToken.build() method I forgot to get the Timeout values from the configuration. This causes the default timeout to be 20ms, which causes a lot of timeout errors if your internet is not working good enough. When I did PR79 I tried it out and it worked, noticed some days later. 

regards Peter.