### PR TITLE
#83 adjusted file name normalisation in XeroClient.createAttachment

### DIFF
--- a/src/main/java/com/xero/api/XeroClient.java
+++ b/src/main/java/com/xero/api/XeroClient.java
@@ -22,6 +22,9 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
 public class XeroClient {
 
     private XeroExceptionHandler xeroExceptionHandler;
@@ -1847,18 +1850,50 @@ public class XeroClient {
             throws IOException {
     		return createAttachment(endpoint, guid, filename, contentType, bytes, false);
     }
-   
-    public Attachment createAttachment(String endpoint, String guid, String filename, String contentType, byte[] bytes, boolean includeOnline)
-    		throws IOException {
-    		Map<String, String> params = new HashMap<>();
-    		if (includeOnline) {
-    			params.put("IncludeOnline", Boolean.toString(true));
-    		}
-    		String alphaNumbericFileName = filename.replaceAll("[^\\p{L}\\p{Z}\\.]", "").replaceAll(" ", "_");
-    		return singleResult(put(endpoint + "/" + guid + "/Attachments/" + alphaNumbericFileName, contentType, bytes, params)
-    				.getAttachments()
-    				.getAttachment());
+
+    public Attachment createAttachment(
+        final String endpoint,
+        final String guid,
+        final String filename,
+        final String contentType,
+        final byte[] bytes,
+        final boolean includeOnline) throws IOException {
+
+        requireNonNull(endpoint, "endpoint must not be null");
+        requireNonNull(guid, "guid must not be null");
+        requireNonNull(filename, "filename must not be null");
+        requireNonNull(contentType, "contentType must not be null");
+        requireNonNull(bytes, "bytes must not be null");
+
+        final HashMap<String, String> params = new HashMap();
+        if (includeOnline) {
+            params.put("IncludeOnline",  Boolean.toString(true));
+        }
+
+        final String alphaNumericFileName = normalizeFileNameForURI(filename);
+        return singleResult(
+            put(
+                format("%s/%s/Attachments/%s",endpoint, guid, alphaNumericFileName),
+                contentType,
+                bytes,
+                params
+            ).getAttachments().getAttachment());
     }
+
+
+    /**
+     * Normalizes file name with respect to https://tools.ietf.org/html/rfc3986#section-2.3
+     *
+     * @param fileName
+     * @return file name which does not contain invalid URI characters
+     */
+    protected String normalizeFileNameForURI(final String fileName) {
+        return fileName
+            .trim()
+            .replaceAll(" ", "_")
+            .replaceAll("[^\\p{Alnum}\\-_.~]", "");
+    }
+
 
     public String getAttachmentContent(String endpoint, String guid, String filename, String accept, String dirPath)
         throws IOException {

--- a/src/test/java/com/xero/api/XeroClientTest.java
+++ b/src/test/java/com/xero/api/XeroClientTest.java
@@ -1,0 +1,28 @@
+package com.xero.api;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class XeroClientTest {
+
+    private XeroClient xeroClient;
+
+    @Before
+    public void setup() {
+        xeroClient = new XeroClient(null, null);
+    }
+
+    @Test
+    public void testNormalizeFileNameForURI() {
+        assertEquals("1527238288566.png", xeroClient.normalizeFileNameForURI("1527238288566.png"));
+        assertEquals("V12_abc.png", xeroClient.normalizeFileNameForURI("V12 abc.png"));
+        assertEquals("Ab1_23ab.png", xeroClient.normalizeFileNameForURI("Ab1 23ab.png"));
+        assertEquals("abc.png", xeroClient.normalizeFileNameForURI(" abc.png "));
+        assertEquals("a-b.png", xeroClient.normalizeFileNameForURI("a-b.png"));
+        assertEquals("a_b.png", xeroClient.normalizeFileNameForURI("a_b.png"));
+        assertEquals("a__b.png", xeroClient.normalizeFileNameForURI("a  b.png"));
+        assertEquals("a~b.png", xeroClient.normalizeFileNameForURI("a~b.png"));
+    }
+}


### PR DESCRIPTION
Hi,
please have a look in the adjustment in the file name normalisation in `XeroClient.createAttachment()`. We needed to fix it on our side but we believe it might be interesting for the community as well.