### PR TITLE
Migration to log4j2

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,17 +176,17 @@ log4j.properties
 log4j.rootLogger=DEBUG, stdout, file
 
 # Redirect log messages to console
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout=org.apache.logging.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout=org.apache.logging.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 # Redirect log messages to a log file, support file rolling.
-log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file=org.apache.logging.log4j.RollingFileAppender
 log4j.appender.file.File=/Users/sid.maestre/logs/log4j-application.log
 log4j.appender.file.MaxFileSize=5MB
 log4j.appender.file.MaxBackupIndex=10
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout=org.apache.logging.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 ```
 

--- a/example/src/main/resources/log4j.properties
+++ b/example/src/main/resources/log4j.properties
@@ -2,15 +2,15 @@
 log4j.rootLogger=DEBUG, stdout, file
 
 # Redirect log messages to console
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout=org.apache.logging.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout=org.apache.logging.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 # Redirect log messages to a log file, support file rolling.
-log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file=org.apache.logging.log4j.RollingFileAppender
 log4j.appender.file.File=/Users/sid.maestre/logs/log4j-application.log
 log4j.appender.file.MaxFileSize=5MB
 log4j.appender.file.MaxBackupIndex=10
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout=org.apache.logging.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,11 @@
 		    <artifactId>httpclient</artifactId>
 		    <version>4.5.3</version>
 		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.11.0</version>
+        </dependency>
     </dependencies>
 	<repositories>
 		<repository>

--- a/src/main/java/com/xero/api/OAuthParameters.java
+++ b/src/main/java/com/xero/api/OAuthParameters.java
@@ -18,10 +18,11 @@ import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class OAuthParameters implements HttpExecuteInterceptor, HttpRequestInitializer {
-	final static Logger logger = Logger.getLogger(OAuthParameters.class);
+	final static Logger logger = LogManager.getLogger(OAuthParameters.class);
 	   
 	public OAuthParameters()  {
 

--- a/src/main/java/com/xero/api/OAuthRequestResource.java
+++ b/src/main/java/com/xero/api/OAuthRequestResource.java
@@ -41,7 +41,8 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.api.client.auth.oauth.OAuthSigner;
 import com.google.api.client.http.GenericUrl;
@@ -66,7 +67,7 @@ public class OAuthRequestResource {
 	private Config config;
 	private SignerFactory signerFactory;
 	private String fileName;
-	final static Logger logger = Logger.getLogger(OAuthRequestResource.class);
+	final static Logger logger = LogManager.getLogger(OAuthRequestResource.class);
 
 	private OAuthRequestResource(Config config, SignerFactory signerFactory, String resource, String method, Map<? extends String, ?> params) {
 		this.config = config;

--- a/src/main/java/com/xero/api/OAuthRequestToken.java
+++ b/src/main/java/com/xero/api/OAuthRequestToken.java
@@ -3,7 +3,8 @@ package com.xero.api;
 import java.io.IOException;
 import java.util.HashMap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.api.client.auth.oauth.OAuthCredentialsResponse;
 import com.google.api.client.auth.oauth.OAuthSigner;
@@ -15,7 +16,7 @@ public class OAuthRequestToken {
   private OAuthGetTemporaryToken tokenRequest = null;
   private Config config;
   private SignerFactory signerFactory;
-  final static Logger logger = Logger.getLogger(OAuthRequestToken.class);
+  final static Logger logger = LogManager.getLogger(OAuthRequestToken.class);
   
   public OAuthRequestToken(Config config) {
     this(config, new ConfigBasedSignerFactory(config));

--- a/src/main/java/com/xero/api/RsaSignerFactory.java
+++ b/src/main/java/com/xero/api/RsaSignerFactory.java
@@ -7,14 +7,15 @@ import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.util.Collections;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.api.client.auth.oauth.OAuthRsaSigner;
 
 public class RsaSignerFactory implements SignerFactory {
 
   private OAuthRsaSigner signer = new OAuthRsaSigner();
-  final static Logger logger = Logger.getLogger(RsaSignerFactory.class);
+  final static Logger logger = LogManager.getLogger(RsaSignerFactory.class);
   
   public RsaSignerFactory(String pathToPrivateKey, String privateKeyPassword) {
     this(RsaSignerFactory.class.getResourceAsStream(pathToPrivateKey), privateKeyPassword);

--- a/src/main/java/com/xero/api/XeroClient.java
+++ b/src/main/java/com/xero/api/XeroClient.java
@@ -6,7 +6,8 @@ import com.xero.model.*;
 
 import javax.xml.bind.JAXBElement;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -32,7 +33,7 @@ public class XeroClient {
     private SignerFactory signerFactory;
     private String token = null;
     private String tokenSecret = null;
-    final static Logger logger = Logger.getLogger(XeroClient.class);
+    final static Logger logger = LogManager.getLogger(XeroClient.class);
     static XeroJAXBMarshaller u = new XeroJAXBMarshaller();
     protected static final DateFormat utcFormatter;
 

--- a/src/main/java/com/xero/api/XeroHttpContext.java
+++ b/src/main/java/com/xero/api/XeroHttpContext.java
@@ -21,14 +21,15 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class XeroHttpContext {
 	private Config config;
 	private String accept;
 	private String contentType;
 	private String ifModifiedSince = null;
-	final static Logger logger = Logger.getLogger(XeroHttpContext.class);
+	final static Logger logger = LogManager.getLogger(XeroHttpContext.class);
 	
 	public XeroHttpContext(Config config)
 	{

--- a/src/main/java/com/xero/api/exception/XeroExceptionHandler.java
+++ b/src/main/java/com/xero/api/exception/XeroExceptionHandler.java
@@ -16,15 +16,16 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This class is to handle Xero API exceptions with the help of the {@link XeroJAXBMarshaller}
  */
 public class XeroExceptionHandler {
 
-    //private final static Logger LOGGER = Logger.getLogger(XeroExceptionHandler.class.getName());
-    final static Logger logger = Logger.getLogger(XeroExceptionHandler.class);
+    //private final static Logger logger = LogManager.getLogger(XeroExceptionHandler.class.getName());
+    final static Logger logger = LogManager.getLogger(XeroExceptionHandler.class);
     
     private static final Pattern MESSAGE_PATTERN = Pattern.compile("<Message>(.*)</Message>");
     private XeroJAXBMarshaller xeroJaxbMarshaller;

--- a/src/main/java/com/xero/example/RequestResourceServlet.java
+++ b/src/main/java/com/xero/example/RequestResourceServlet.java
@@ -21,7 +21,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.xero.api.XeroClient;
 import com.xero.api.Config;
@@ -35,7 +36,7 @@ public class RequestResourceServlet extends HttpServlet
 {
 	private static final long serialVersionUID = 1L; 
 	private Config config = JsonConfig.getInstance();
-    final static Logger logger = Logger.getLogger(OAuthRequestResource.class);
+    final static Logger logger = LogManager.getLogger(OAuthRequestResource.class);
    
 	private String htmlString =  "<link rel=\"stylesheet\" href=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css\" integrity=\"sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7\" crossorigin=\"anonymous\">"
 			+ "<link rel=\"stylesheet\" href=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css\" integrity=\"sha384-fLW2N01lMqjakBkx3l/M9EahuwpSfeNvV63J5ezn3uZzapT0u7EYsXMjQV+0En5r\" crossorigin=\"anonymous\">"


### PR DESCRIPTION
Log4j version 1 is deprecated and End of Life, users are recommended to migrate to Logj4 version 2, see https://blogs.apache.org/foundation/entry/apache_logging_services_project_announces

The last log4j release was in 2012 and EOL was announced in 2015.

Spring Boot 2.0.x which has Spring web 5.0.x currently warns this on startup:

```
log4j:WARN No appenders could be found for logger (org.springframework.web.context.support.StandardServletEnvironment).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
```

Migration to log4j2 was performed using these instructions and i have confirmed logging working with Spring boot 2 - https://logging.apache.org/log4j/2.x/manual/migration.html