### PR TITLE
Exclude junit from json-simple dependency as it does not specify juni…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
 			<groupId>com.googlecode.json-simple</groupId>
 			<artifactId>json-simple</artifactId>
 			<version>1.1.1</version>
+			<exclusions>
+				<!-- json-simple incorrectly includes junit in compile scope -->
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>


### PR DESCRIPTION
The json-simple library does not provide the test scope on its junit dependency. Junit is therefore incorrectly included in the compilation.

[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ xero-java ---
[INFO] com.github.xeroapi:xero-java:jar:4.2.0
[INFO] \- com.googlecode.json-simple:json-simple:jar:1.1.1:compile
[INFO]    \- junit:junit:jar:4.10:compile

https://github.com/fangyidong/json-simple/issues/91

Junit should be excluded from the json-simple dependency