### PR TITLE
#264 add XeroRateLimitException subtypes

### DIFF
--- a/src/main/java/com/xero/api/XeroAppMinuteRateLimitException.java
+++ b/src/main/java/com/xero/api/XeroAppMinuteRateLimitException.java
@@ -1,0 +1,12 @@
+package com.xero.api;
+
+public class XeroAppMinuteRateLimitException extends XeroRateLimitException {
+
+    private static final long serialVersionUID = 1L;
+
+    public XeroAppMinuteRateLimitException(final int statusCode, final Integer appLimitRemaining, final Integer dayLimitRemaining,
+                                           final Integer minuteLimitRemaining,
+                                           final Long retryAfterSeconds, final String message, final Exception e) {
+        super(statusCode, appLimitRemaining, dayLimitRemaining, minuteLimitRemaining, retryAfterSeconds, message, e);
+    }
+}

--- a/src/main/java/com/xero/api/XeroDailyRateLimitException.java
+++ b/src/main/java/com/xero/api/XeroDailyRateLimitException.java
@@ -1,0 +1,12 @@
+package com.xero.api;
+
+public class XeroDailyRateLimitException extends XeroRateLimitException {
+
+    private static final long serialVersionUID = 1L;
+
+    public XeroDailyRateLimitException(final int statusCode, final Integer appLimitRemaining, final Integer dayLimitRemaining,
+                                       final Integer minuteLimitRemaining,
+                                       final Long retryAfterSeconds, final String message, final Exception e) {
+        super(statusCode, appLimitRemaining, dayLimitRemaining, minuteLimitRemaining, retryAfterSeconds, message, e);
+    }
+}

--- a/src/main/java/com/xero/api/XeroMinuteRateLimitException.java
+++ b/src/main/java/com/xero/api/XeroMinuteRateLimitException.java
@@ -1,0 +1,12 @@
+package com.xero.api;
+
+public class XeroMinuteRateLimitException extends XeroRateLimitException {
+
+    private static final long serialVersionUID = 1L;
+
+    public XeroMinuteRateLimitException(final int statusCode, final Integer appLimitRemaining, final Integer dayLimitRemaining,
+                                        final Integer minuteLimitRemaining,
+                                        final Long retryAfterSeconds, final String message, final Exception e) {
+        super(statusCode, appLimitRemaining, dayLimitRemaining, minuteLimitRemaining, retryAfterSeconds, message, e);
+    }
+}

--- a/src/main/java/com/xero/api/XeroRateLimitException.java
+++ b/src/main/java/com/xero/api/XeroRateLimitException.java
@@ -1,15 +1,45 @@
 package com.xero.api;
 
+/**
+ * Base application exception all other rate limit Xero exceptions should extend
+ */
 public class XeroRateLimitException extends XeroException {
 
     private static final long serialVersionUID = 1L;
     private int statusCode = 0;
     private String message;
-    
-    public XeroRateLimitException(int statusCode, String message, Exception e) {
+
+    /**
+     * The remaining app limit
+     */
+    private final Integer appLimitRemaining;
+
+    /**
+     * The remaining day limit
+     */
+    private final Integer dayLimitRemaining;
+
+    /**
+     * The remaining minute limit
+     */
+    private final Integer minuteLimitRemaining;
+
+    /**
+     * retryAfterSeconds that tells you how many seconds to wait before making another request.
+     * Requests are counted against a fixed window which will reset at different times for each tenant.
+     * It is important to use the Retry-After header to know when you can start making calls again.
+     */
+    private final Long retryAfterSeconds;
+
+    public XeroRateLimitException(int statusCode, Integer appLimitRemaining, Integer dayLimitRemaining, Integer minuteLimitRemaining,
+                                  Long retryAfterSeconds, String message, Exception e) {
         super(statusCode + " : " + message, e);
         this.statusCode = statusCode;
+        this.appLimitRemaining = appLimitRemaining;
+        this.dayLimitRemaining = dayLimitRemaining;
+        this.minuteLimitRemaining = minuteLimitRemaining;
         this.message = message;
+        this.retryAfterSeconds = retryAfterSeconds;
     }
 
     public int getStatusCode() {
@@ -20,4 +50,19 @@ public class XeroRateLimitException extends XeroException {
         return message;
     }
 
+    public Integer getAppLimitRemaining() {
+        return appLimitRemaining;
+    }
+
+    public Integer getDayLimitRemaining() {
+        return dayLimitRemaining;
+    }
+
+    public Integer getMinuteLimitRemaining() {
+        return minuteLimitRemaining;
+    }
+
+    public long getRetryAfterSeconds() {
+        return retryAfterSeconds;
+    }
 }


### PR DESCRIPTION
- Added XeroAppMinuteRateLimitException, XeroDailyRateLimitException and XeroMinuteRateLimitException of which all 3 extend XeroRateLimitException
- As a result all existing implementations that catch XeroRateLimitException will still work regardless of which RateLimitException is thrown
- Not a breaking change
- Updated README with new exception types and try/catch example
- added tests to XeroExceptionsTest for new exception types
- RateLimitExceptions now has retryAfterSeconds that tells you how many seconds to wait before making another request

