### PR TITLE
Updated insecure jackson-databind, with upgrades to jackson-version and mockito to support change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.5.13</version>
+            <version>4.5.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -315,8 +315,8 @@
 		<swagger-annotations-version>1.5.17</swagger-annotations-version>
 		<google-api-client-version>1.23.0</google-api-client-version>
 		<jersey-common-version>2.25.1</jersey-common-version>
-		<jackson-version>2.9.10</jackson-version>
-		<jackson-databind-version>2.9.10.7</jackson-databind-version>
+		<jackson-version>2.13.2</jackson-version>
+		<jackson-databind-version>2.13.2.2</jackson-databind-version>
 		<jackson-threetenbp-version>2.6.4</jackson-threetenbp-version>
         <junit-version>4.13.1</junit-version>
         <org-apache-httpcomponents>4.5.3</org-apache-httpcomponents>


### PR DESCRIPTION
Upgraded mockito to 4.5.1 to allow tests to build properly.
Upgraded jackson-version to 2.13.2 to allow jackson-databind to be upgraded to 2.13.2.2

This resolves 14 major security issues with 2.9.10.7 that was in use
Information on the vulnerabilities for jackson-databind available at
https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind